### PR TITLE
Bux fix: Menu items dissapear when clicked

### DIFF
--- a/web/css/custom.css
+++ b/web/css/custom.css
@@ -114,3 +114,14 @@ div.candidate span.matches a.google-link {
 .text-muted {
     color: #9a9a9a;
 }
+.nav-head .navbar-default  .navbar-nav > li.open a{
+    background: none;	
+    color: #555 ;
+}
+.nav-head .navbar-default  .navbar-nav > li > a:active,
+.overrides .nav-head .navbar-default  .navbar-nav > li > a:focus{
+    background: none !important;	
+    color: #555 !important;
+}
+
+


### PR DESCRIPTION
Comment lines 473 and 510 (Color: #fff) in order to keep the color of menu item instead of turning to white.